### PR TITLE
Don't have a double tirplet in the vcpkg_installed

### DIFF
--- a/scripts/buildsystems/msbuild/vcpkg.targets
+++ b/scripts/buildsystems/msbuild/vcpkg.targets
@@ -51,7 +51,7 @@
   <Choose>
     <When Condition="'$(VcpkgEnableManifest)' == 'true'">
       <PropertyGroup>
-        <_ZVcpkgInstalledDir Condition="'$(_ZVcpkgInstalledDir)' == ''">$(_ZVcpkgManifestRoot)vcpkg_installed\$(VcpkgTriplet)\</_ZVcpkgInstalledDir>
+        <_ZVcpkgInstalledDir Condition="'$(_ZVcpkgInstalledDir)' == ''">$(_ZVcpkgManifestRoot)vcpkg_installed\</_ZVcpkgInstalledDir>
       </PropertyGroup>
     </When>
     <Otherwise>


### PR DESCRIPTION
Fix the private property in the msbuild vcpkg.targets so it doesn't generate a path with two vcpkg_triplet values in it.