### PR TITLE
PACK-6662: Update ffmpeg dependency to latest ffmpeg from vcpkg

### DIFF
--- a/ports/rapidxml/0001-fix-for-a-bug-in-gcc-that-won-t-let-rapidxml-compile.patch
+++ b/ports/rapidxml/0001-fix-for-a-bug-in-gcc-that-won-t-let-rapidxml-compile.patch
@@ -1,0 +1,32 @@
+From 2cf47bb8fb1de71bb2d2e059c15a30ffa4ca4cd6 Mon Sep 17 00:00:00 2001
+From: Ferdinand Niedermann <ferdinand.niedermann@gmail.com>
+Date: Sat, 21 Sep 2013 01:55:58 +0200
+Subject: [PATCH] fix for a bug in gcc that won't let rapidxml compile on clang
+
+---
+ rapidxml_print.hpp | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+--- a/rapidxml_print.hpp
++++ b/rapidxml_print.hpp
+@@ -102,6 +102,20 @@
+         ///////////////////////////////////////////////////////////////////////////
+         // Internal printing operations
+     
++        // =====================================
++        // fix for clang for this bug in gcc and others: http://sourceforge.net/p/rapidxml/bugs/16/
++
++        template<class OutIt, class Ch> inline OutIt print_children(OutIt out, const xml_node<Ch> *node, int flags, int indent);
++        template<class OutIt, class Ch> inline OutIt print_element_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
++        template<class OutIt, class Ch> inline OutIt print_data_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
++        template<class OutIt, class Ch> inline OutIt print_cdata_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
++        template<class OutIt, class Ch> inline OutIt print_declaration_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
++        template<class OutIt, class Ch> inline OutIt print_comment_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
++        template<class OutIt, class Ch> inline OutIt print_doctype_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
++        template<class OutIt, class Ch> inline OutIt print_pi_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
++
++        // =====================================
++
+         // Print node
+         template<class OutIt, class Ch>
+         inline OutIt print_node(OutIt out, const xml_node<Ch> *node, int flags, int indent)

--- a/ports/rapidxml/portfile.cmake
+++ b/ports/rapidxml/portfile.cmake
@@ -5,6 +5,8 @@ vcpkg_from_sourceforge(
     REF rapidxml%201.13
     FILENAME "rapidxml-1.13.zip"
     SHA512 6c10583e6631ccdb0217d0a5381172cb4c1046226de6ef1acf398d85e81d145228e14c3016aefcd7b70a1db8631505b048d8b4f5d4b0dbf1811d2482eefdd265
+    PATCHES
+        0001-fix-for-a-bug-in-gcc-that-won-t-let-rapidxml-compile.patch
 )
 
 # Handle copyright

--- a/ports/rapidxml/vcpkg.json
+++ b/ports/rapidxml/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "rapidxml",
   "version-string": "1.13",
-  "port-version": 5,
+  "port-version": 6,
   "description": "RapidXml is an attempt to create the fastest XML parser possible, while retaining useability, portability and reasonable W3C compatibility.",
   "homepage": "https://sourceforge.net/projects/rapidxml"
 }


### PR DESCRIPTION
- Add a patch to rapidxml that's required to build under clang or gcc. The patch is present in Ubuntu (which is how it was previously working) and we also use it for our Thin Client builds under Yocto.

**Describe the pull request**

- #### What does your PR fix?
  Fixes #...

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  <all / linux, windows, ...>, <Yes/No>

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  `Your answer`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  <Yes / I am still working on this PR>

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
